### PR TITLE
Git ignore .ruby-version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,5 @@
 /pkg/
 /spec/reports/
 /tmp/
+
+.ruby-version


### PR DESCRIPTION
Allows devs to autoset ruby version using the .ruby-version file, but have it ignored by git.