### PR TITLE
Count line numbers using ruby's IO, not shellout

### DIFF
--- a/lib/memory_analyzer/heap_analyzer/parser.rb
+++ b/lib/memory_analyzer/heap_analyzer/parser.rb
@@ -25,7 +25,7 @@ module MemoryAnalyzer
       def parse_file_with_progress
         progress = ProgressBar.create(
           :title         => "Parsing",
-          :total         => `wc -l #{file}`.split.first.to_i,
+          :total         => File.open(file) {|f| f.each_line.count },
           :format        => "%t: |%B| %e",
           :throttle_rate => 0.1
         )


### PR DESCRIPTION
Makes the progressbar code more portable since it doesn't rely on shell cmds being present on the system (e.g. Windows users).  Roughly the same performance, and any IO object that responds to `#each_line` can technically be swapped in here to do the same (SPOILERS: will happen in a future pull request)