### PR TITLE
Support reading gzip files

### DIFF
--- a/lib/memory_analyzer/heap_analyzer/parser.rb
+++ b/lib/memory_analyzer/heap_analyzer/parser.rb
@@ -97,12 +97,17 @@ module MemoryAnalyzer
       end
 
       def io_class
-        if File.extname(file) == ".gz"
+        if has_gzip_magic_number? || File.extname(file) == ".gz"
           require 'zlib'
           Zlib::GzipReader
         else
           File
         end
+      end
+
+      GZ_MAGIC_NUMBER = "\x1F\x8B".force_encoding("ASCII-8BIT").freeze
+      def has_gzip_magic_number?
+        File.binread(file, 2) == GZ_MAGIC_NUMBER
       end
     end
   end

--- a/lib/memory_analyzer/heap_analyzer/parser.rb
+++ b/lib/memory_analyzer/heap_analyzer/parser.rb
@@ -25,7 +25,7 @@ module MemoryAnalyzer
       def parse_file_with_progress
         progress = ProgressBar.create(
           :title         => "Parsing",
-          :total         => `wc -l #{file}`.split.first.to_i,
+          :total         => File.open(file) {|f| f.each_line.count },
           :format        => "%t: |%B| %e",
           :throttle_rate => 0.1
         )


### PR DESCRIPTION
Built off of https://github.com/Fryguy/memory_analyzer/pull/4

When comparing sizes of a memory dump file when compressed and not:

```console
$ ls -lh tmp/sample_dumps
total 1256264
-rw-r--r--  1 user  staff   576M Jan 01 19:08 dump
-rw-r--r--  1 user  staff    37M Jan 01 19:09 dump.gz
```

The disk space requirements to keep around a gzipped file are far more beneficial instead of it's uncompressed counterpart, and the time difference and memory requirements to parse a gzip file versus a uncompressed file are next to none.

```console
$ time ruby bin/memory_analyzer tmp/sample_dumps/dump.gz
Parsing: |========================================| Time: 00:03:11
Mem: 3695.37890625MiB

real    3m14.405s
user    3m11.839s
sys     0m2.357s
$ time ruby bin/memory_analyzer tmp/sample_dumps/dump
Parsing: |========================================| Time: 00:03:11
Mem: 3625.39453125MiB

real    3m13.220s
user    3m10.516s
sys     0m2.522s
```

Changes
-------

This PR adds the `#io_klass` which will look at the filename's extension to determine if it is a gzipped file (probably a better way to do this), and then uses chooses the proper IO class to read the file with.  The `ProgressBar` `:total` option also makes use of this method.

If the file is a gzip file, it will require the zlib library and use the `Zlib::GzipReader` class to parse the file.

The `#parse_file` method needed to be modified slightly to use a common API between the `Zlib::GzipReader` and `File` classes, but changes to the method functionally equivalent to the old implementation.